### PR TITLE
Add #ifdefs for Open Solaris

### DIFF
--- a/source/include/util.h
+++ b/source/include/util.h
@@ -8,7 +8,7 @@ extern int grep(char **, char *);
 extern char * strcasestr(const char *, const char *);
 extern char * strjoin(const char *, ...);
 
-#if ((defined(__FreeBSD__) || defined(__OpenBSD__)) || defined(__darwin__) && !defined(__STRNDUP__))
+#if ((defined(__FreeBSD__) || defined(__OpenBSD__)) || defined(__darwin__) || (defined (__SVR4) && defined (__sun)) && !defined(__STRNDUP__))
 #define __STRNDUP__
 extern char * strndup(const char *, size_t);
 #endif

--- a/source/util.c
+++ b/source/util.c
@@ -176,7 +176,7 @@ char * strndup(const char * src, size_t len) {
 
 #endif
 
-#if (defined(TUXBOX) || defined(PPC))
+#if (defined(TUXBOX) || defined(PPC) || (defined (__SVR4) && defined (__sun)))
 
 /* On a few system like a PPC based Dreambox libc does not include strcasestr ... */
 


### PR DESCRIPTION
Hi jkramer, bartman,

I added to the #ifdefs to make the build work on my (x86_64) Open Solaris box.
Please double check that I'm not breaking anything, as I'm a total n00b to github and also did not completely get shell-fm's build process (shell-fm won't build on my i386 intel Ubuntu box ATM).

Thanks for your great work which I enjoy a lot.

Florian
