### PR TITLE
Escape empty shell arguments

### DIFF
--- a/source/interface.c
+++ b/source/interface.c
@@ -514,6 +514,13 @@ char * shellescape(const char * string) {
 	assert(string != NULL);
 
 	size = strlen(string) * 2 + 1;
+	/*
+	 * Be sure to still escape the empty string. I.e., ./blah a b
+	 * is different from ./blah a "" b.
+	 */
+	if (size <= 1)
+	  size += 2;
+
 	escaped = malloc(size);
 	memset(escaped, 0, size);
 
@@ -526,6 +533,10 @@ char * shellescape(const char * string) {
 		escaped[length++] = string[n];
 		escaped[length] = 0;
 	}
+
+	/* escape the empty string... */
+	if (!length)
+		memcpy(escaped, "\"\"", 2);
 
 	return escaped;
 }


### PR DESCRIPTION
The current shell-fm version will escape expanded arguments to the np-cmd shellout command. This means that putting double-quotes around these arguments breaks the escaping. However, this built-in escaping does not escape an empty string as "".

Certain scritps supporting np-cmd shellouts, such as shellfm-notify, require a rigid structure of arguments. shellfm-notify requires
    shellfm-notify <artist> <track> <album>
, which corresponds to np-cmd = shellfm-notify %a %t %l. However, when the album is empty, shell-fm will execute
    shellfm-notify An\ Artist Trickety\ Track
instead of
    shellfm-notify An\ Artist Trickety\ Track ""
. This causes shellfm-notify to exit in error. It would be worse if the artist or track were empty strings somehow (which won't ever happen) or if there is any argument after the album argument which the application would interpret as the artist instead of its intended value.

My commit fixes this.
