### PR TITLE
Memory leak with persistant socket connections

### DIFF
--- a/source/sckif.c
+++ b/source/sckif.c
@@ -148,8 +148,11 @@ void accept_client(int listen_socket) {
 
 
 void handle_client(int client_socket) {
-	FILE * fd = fdopen(client_socket, "rw");
+	static FILE * fd = NULL;
 	int disconnect = 0;
+
+	if (!fd)
+		fd = fdopen(client_socket, "rw");
 
 	signal(SIGPIPE, SIG_IGN);
 


### PR DESCRIPTION
Hi,

there's a bug in handle_client() when client sockets are kept open. Instead of being reused, a new FILE\* is opened on each call.
Both UNIX and TCP sockets are affected.

We're using shell-fm on an embedded NAS device (NSLU2) together with an IRC bot, which is polling for new info every three seconds. We got up-times of about 60..120 minutes until it crashed :-)

Jomat
