### PR TITLE
shell-fm segault sometimes

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -10,9 +10,6 @@ CFLAGS  += -Os -Wall -MD -W -I./include/
 ifdef EXTERN_ONLY
 	CFLAGS += -DEXTERN_ONLY
 else
-ifeq ($(shell uname -s), OpenBSD)
-	LDLIBS += -lossaudio
-endif
 ifeq ($(shell uname -s), NetBSD)
 	LDLIBS += -lossaudio
 endif

--- a/source/interface.c
+++ b/source/interface.c
@@ -416,7 +416,7 @@ const char * meta(const char * fmt, int flags, struct hash * track) {
 					snprintf(colorkey, sizeof(colorkey), "%c-color", fmt[x]);
 					color = value(& rc, colorkey);
 
-					if(color) {
+					if(strlen(color)) {
 						/* Strip leading spaces from end of color (Author: Ondrej Novy) */
 						char * color_st = strdup(color);
 						size_t len = strlen(color_st) - 1;


### PR DESCRIPTION
Hi,

Shell-fm segfaults sometimes on my computer. I have investigated with git bisect and it seems to be related to c191f2f .But I don't understand the relation between this commit and the place where shell-fm segfault. Here is the gdb backtrace and my shell-fm.rc:

<pre>
(413)$ gdb source/shell-fm /home/amaury/shell-fm-jkramer.core  
GNU gdb 6.3
Copyright 2004 Free Software Foundation, Inc.
GDB is free software, covered by the GNU General Public License, and you are
welcome to change it and/or distribute copies of it under certain conditions.
Type "show copying" to see the conditions.
There is absolutely no warranty for GDB.  Type "show warranty" for details.
This GDB was configured as "amd64-unknown-openbsd4.9"...

Core was generated by `shell-fm'.
Program terminated with signal 11, Segmentation fault.
Reading symbols from /usr/lib/libossaudio.so.3.1...done.
Loaded symbols for /usr/lib/libossaudio.so.3.1
Reading symbols from /usr/local/lib/libmad.so.2.1...done.
Loaded symbols for /usr/local/lib/libmad.so.2.1
Reading symbols from /usr/lib/libm.so.5.2...done.
Loaded symbols for /usr/lib/libm.so.5.2
Reading symbols from /usr/local/lib/libao.so.4.0...done.
Loaded symbols for /usr/local/lib/libao.so.4.0
Reading symbols from /usr/local/lib/libtag_c.so.2.0...done.
Loaded symbols for /usr/local/lib/libtag_c.so.2.0
Reading symbols from /usr/local/lib/libtag.so.8.0...done.
Loaded symbols for /usr/local/lib/libtag.so.8.0
Reading symbols from /usr/lib/libc.so.58.0...done.
Loaded symbols for /usr/lib/libc.so.58.0
Reading symbols from /usr/lib/libz.so.4.1...done.
Loaded symbols for /usr/lib/libz.so.4.1
Reading symbols from /usr/lib/libstdc++.so.50.0...done.
Loaded symbols for /usr/lib/libstdc++.so.50.0
Reading symbols from /usr/libexec/ld.so...done.
Loaded symbols for /usr/libexec/ld.so
#0  meta (fmt=0x511c2b "%r", flags=Variable "flags" is not available.
) at interface.c:426
426                                                     while(isspace(color_st[len]) && len > 0) {
(gdb) bt full
#0  meta (fmt=0x511c2b "%r", flags=Variable "flags" is not available.
) at interface.c:426
        color_st = 0x20e607000 ""
        len = 18446744073709551615
        colorkey = "r-color", '\0' <repeats 56 times>
        val = 0x20a918de0 " 02:55"
        track_key = Variable "track_key" is not available.
(gdb) p color
$1 = 0x511bf3 ""
(gdb) 

(415)$ cat .shell-fm/shell-fm.rc                                                                                                   
username = foo
password = bar
default-radio = user/captainpatate
</pre>


Cheers,
Amaury
