### PR TITLE
Update the package version value to 0.8 to match the latest release.

### DIFF
--- a/source/include/settings.h
+++ b/source/include/settings.h
@@ -5,7 +5,7 @@
 #ifndef SHELLFM_SETTINGS
 #define SHELLFM_SETTINGS
 
-#define PACKAGE_VERSION "0.7"
+#define PACKAGE_VERSION "0.8"
 
 #include "hash.h"
 


### PR DESCRIPTION
I suppose this needs to be changed since shell-fm is on version 0.8 and anyone pulling the latest version will still see the version as 0.7.
