### PR TITLE
Don't display timeout message when stopping playback.

### DIFF
--- a/source/play.c
+++ b/source/play.c
@@ -558,7 +558,8 @@ static int timed_read(int fd, unsigned char * p, int count, int timeout) {
 		return read(fd, p, count);
 	}
 
-	fprintf(stderr, "Track stream timed out (%d).\n", timeout);
+	if (!killed)
+		fprintf(stderr, "Track stream timed out (%d).\n", timeout);
 	return -1;
 }
 #endif


### PR DESCRIPTION
I see this error message all the time when I skip a track before it starts playing. Does this fix make sense?
