### PR TITLE
Downloading

### DIFF
--- a/manual/shell-fm.1
+++ b/manual/shell-fm.1
@@ -64,6 +64,10 @@ Enabled/disable discovery mode. I'm not sure if this has any effect, and it
 looks like even the Last.FM guys don't really know what it does, but I think it
 is meant to ensure that you get only tracks that you don't know yet.
 .TP
+.B D
+Save the current track. This only has an effect if downloading is configured and
+no-auto-download is set.
+.TP
 .B f
 Jump to the fan radio station of the artist of the currently played track.
 .TP
@@ -310,6 +314,10 @@ is free, it is saved at the given place.
 Buffer downloaded tracks in the file given by download-tmp. If this is set,
 it may help to avoid creating empty directories, e.g. when a track is skipped.
 This should point to the same filesystem as download.
+.TP
+.B no-auto-download = something
+Store the track only when told so from the interface. (In contrast to storing
+all tracks)
 .TP
 .B gap = seconds
 If this is set to a number, shell-fm will wait that amount of seconds between

--- a/manual/shell-fm.1
+++ b/manual/shell-fm.1
@@ -306,6 +306,11 @@ Works like screen-format, but sets the x-terminals window title.
 If this is set to a valid path (may contain format flags), and the played track
 is free, it is saved at the given place.
 .TP
+.B download-tmp = format-string
+Buffer downloaded tracks in the file given by download-tmp. If this is set,
+it may help to avoid creating empty directories, e.g. when a track is skipped.
+This should point to the same filesystem as download.
+.TP
 .B gap = seconds
 If this is set to a number, shell-fm will wait that amount of seconds between
 tracks.

--- a/source/interface.c
+++ b/source/interface.c
@@ -138,6 +138,10 @@ void handle_keyboard_input() {
 			}
 			break;
 
+		case 'D':
+			if(playfork)
+				kill(playfork, SIGUSR2);
+			break;
 		case 'A':
 			printf(meta("Really ban all tracks by artist %a? [yN]", M_COLORED, & track));
 			fflush(stdout);


### PR DESCRIPTION
For my usage, I have somewhat modified the downloading behaviour of shell-fm.

I was somewhat annoyed by the empty directories created by  shell-fm in download mode. (This happens if I skip a track or exit shell-fm, for example) The solution for this which appealed most to me is to use a different temporary file for buffering which is placed without the need to create output directories. As it is quite hard to tell where the download "base" directory is, and how filesystems are positioned (obviously the buffer-file should be on the same filesystem as the download path), I made the buffer file a configuration option.

This is almost a necessity for the second patch which allows the user to configure shell-fm in a way so not every track will be stored in the download dir, but only those track which they select.

I think that other users might benefit from these features as well, and they do not change the old behaviour if they are not explicitly configured, therefore, I would like it if these changes would make it to mainline.

Best Regards,
Christian Franke
