### PR TITLE
call atexit(cleanup_term) before authenticating

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -290,6 +290,12 @@ int main(int argc, char ** argv) {
 	/* Catch SIGTSTP to set pausetime when user suspends us with ^Z. */
 	signal(SIGTSTP, stopsig);
 
+	if(!background) {
+		struct input keyboard = { 0, KEYBOARD };
+		register_handle(keyboard);
+		canon(0);
+		atexit(cleanup_term);
+	}
 
 	/* Authenticate to the Last.FM server. */
 	if(haskey(& rc, "password-md5") && !authenticate(value(& rc, "username"), value(& rc, "password-md5")))
@@ -305,14 +311,6 @@ int main(int argc, char ** argv) {
 			fclose(fd);
 		}
 	}
-
-	if(!background) {
-		struct input keyboard = { 0, KEYBOARD };
-		register_handle(keyboard);
-		canon(0);
-		atexit(cleanup_term);
-	}
-
 
 	/* Play default radio, if specified. */
 	if(haskey(& rc, "default-radio")) {


### PR DESCRIPTION
if authentication fails shell-fm exits without calling cleanup_term, which results in the term still being in canonical mode and chars not being echoed to the term, which is annoying.
