### PR TITLE
don't unlink session key

### DIFF
--- a/source/interface.c
+++ b/source/interface.c
@@ -600,7 +600,6 @@ char * shellescape(const char * string) {
 
 
 void quit() {
-	unlink(rcpath("session"));
 	unlinknp();
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
because session keys have an infinite lifetime, keep it until the user
revokes it. This removes the need for application authentication except for the first time the application is run (or if session gets removed some other way) 
