### PR TITLE
Fix port number extraction

### DIFF
--- a/source/http.c
+++ b/source/http.c
@@ -82,7 +82,7 @@ char * fetch(const char * url, FILE ** handle, const char * post, const char * t
 	* file = (char) 0;
 	++file;
 
-	if(port && port < file) {
+	if(port) {
 		char * ptr = NULL;
 		* port = (char) 0;
 		++port;


### PR DESCRIPTION
fixes https://github.com/jkramer/shell-fm/issues/79
basically, two things to say:
1) looks like it was comparing ':' position from proxy's url to '/' position from request's url, that totally has no sense to me
2) in case when no proxy used, valid url should not use colon without escaping in path segment anyway
