### PR TITLE
Fix warnings: -Wduplicate-decl-specifier, -Wmissing-field-initializers

### DIFF
--- a/source/include/util.h
+++ b/source/include/util.h
@@ -8,7 +8,7 @@ extern int grep(char **, char *);
 extern char * strcasestr(const char *, const char *);
 extern char * strjoin(const char *, ...);
 extern void spit(const char *, const char *);
-extern const char const * plain_md5(const char *);
+extern char const * plain_md5(const char *);
 
 #if ((defined(__FreeBSD__) || defined(__OpenBSD__)) || defined(__darwin__) || (defined (__SVR4) && defined (__sun)) && !defined(__STRNDUP__))
 #define __STRNDUP__

--- a/source/json.c
+++ b/source/json.c
@@ -39,7 +39,7 @@
 #ifdef __cplusplus
    const struct _json_value json_value_none; /* zero-d by ctor */
 #else
-   const struct _json_value json_value_none = { 0 };
+   const struct _json_value json_value_none = {};
 #endif
 
 #include <stdlib.h>

--- a/source/rest.c
+++ b/source/rest.c
@@ -16,7 +16,7 @@
 
 static int cmpstringp(const void *, const void *);
 static int restore_key(const char *, char *);
-const char const * build_signature(struct hash *);
+char const * build_signature(struct hash *);
 void create_token();
 
 
@@ -123,7 +123,7 @@ void create_token(void) {
 }
 
 
-const char const * build_signature(struct hash * p) {
+char const * build_signature(struct hash * p) {
 	static char signature[32 + 1] = { 0, };
 	unsigned n, length = 0;
 	char ** const names = malloc(sizeof(char *) * p->size);

--- a/source/util.c
+++ b/source/util.c
@@ -232,7 +232,7 @@ char * strcasestr(const char * haystack, const char * needle) {
 #endif
 
 
-const char const * plain_md5(const char * input) {
+char const * plain_md5(const char * input) {
 	const unsigned char * md5;
 	static char plain[32 + 1] = { 0, };
 	unsigned ndigit;


### PR DESCRIPTION
This silences compile-time warnings with clang 3.4.
